### PR TITLE
Add support for namespace-level type aliases

### DIFF
--- a/apps/api-documenter/src/utils/ToSdpConvertHelper.ts
+++ b/apps/api-documenter/src/utils/ToSdpConvertHelper.ts
@@ -149,7 +149,6 @@ function convertToSDP(transfomredClass: IYamlApiFile): { model: CommonYamlModel;
       }
       return { model: convertToEnumSDP(transfomredClass), type: 'Enum' };
     case 'typealias':
-      console.log('OG ' + element.uid);
       return { model: convertToTypeAliasSDP(element, element.package!, transfomredClass), type: 'TypeAlias' };
     case 'package':
       return {

--- a/apps/api-documenter/src/utils/ToSdpConvertHelper.ts
+++ b/apps/api-documenter/src/utils/ToSdpConvertHelper.ts
@@ -101,7 +101,11 @@ function convertToPackageSDP(transfomredClass: IYamlApiFile): PackageYamlModel {
     const ele: IYamlItem = transfomredClass.items[i];
     switch (ele.type) {
       case 'typealias':
-        // need generate typeAlias file for this
+        if (!packageModel.typeAliases) {
+          packageModel.typeAliases = [];
+        }
+
+        packageModel.typeAliases.push(convertToTypeAliasSDP(ele, element.uid, transfomredClass));
         break;
       case 'function':
         if (!packageModel.functions) {
@@ -120,7 +124,7 @@ function convertToPackageSDP(transfomredClass: IYamlApiFile): PackageYamlModel {
 
 function assignPackageModelFields(
   packageModel: PackageYamlModel,
-  name: 'classes' | 'interfaces' | 'enums' | 'typeAliases',
+  name: 'classes' | 'interfaces' | 'enums',
   uid: string
 ): void {
   if (!packageModel[name]) {
@@ -145,7 +149,8 @@ function convertToSDP(transfomredClass: IYamlApiFile): { model: CommonYamlModel;
       }
       return { model: convertToEnumSDP(transfomredClass), type: 'Enum' };
     case 'typealias':
-      return { model: convertToTypeAliasSDP(element, transfomredClass), type: 'TypeAlias' };
+      console.log('OG ' + element.uid);
+      return { model: convertToTypeAliasSDP(element, element.package!, transfomredClass), type: 'TypeAlias' };
     case 'package':
       return {
         model: convertToPackageSDP(transfomredClass),
@@ -187,9 +192,13 @@ function convertToEnumSDP(transfomredClass: IYamlApiFile): EnumYamlModel {
   return result;
 }
 
-function convertToTypeAliasSDP(element: IYamlItem, transfomredClass: IYamlApiFile): TypeAliasYamlModel {
+function convertToTypeAliasSDP(
+  element: IYamlItem,
+  packageName: string,
+  transfomredClass: IYamlApiFile
+): TypeAliasYamlModel {
   const result: TypeAliasYamlModel = {
-    ...convertCommonYamlModel(element, element.package!, transfomredClass)
+    ...convertCommonYamlModel(element, packageName, transfomredClass)
   } as TypeAliasYamlModel;
 
   if (element.syntax) {

--- a/apps/api-documenter/src/yaml/ISDPYamlFile.ts
+++ b/apps/api-documenter/src/yaml/ISDPYamlFile.ts
@@ -18,7 +18,7 @@ export type PackageYamlModel = CommonYamlModel & {
   classes?: Array<string>;
   interfaces?: Array<string>;
   enums?: Array<string>;
-  typeAliases?: Array<string>;
+  typeAliases?: Array<FunctionYamlModel>;
   properties?: Array<FunctionYamlModel>;
   type?: 'package' | 'module';
   functions?: Array<FunctionYamlModel>;

--- a/build-tests/api-documenter-test/etc/yaml/api-documenter-test.yml
+++ b/build-tests/api-documenter-test/etc/yaml/api-documenter-test.yml
@@ -25,6 +25,52 @@ interfaces:
 enums:
   - 'api-documenter-test!DocEnum:enum'
   - 'api-documenter-test!DocEnumNamespaceMerge:enum'
+typeAliases:
+  - name: ExampleDuplicateTypeAlias
+    uid: 'api-documenter-test!ExampleDuplicateTypeAlias:type'
+    package: api-documenter-test!
+    fullName: ExampleDuplicateTypeAlias
+    summary: A type alias that has duplicate references.
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax: export declare type ExampleDuplicateTypeAlias = SystemEvent | typeof SystemEvent;
+  - name: ExampleTypeAlias
+    uid: 'api-documenter-test!ExampleTypeAlias:type'
+    package: api-documenter-test!
+    fullName: ExampleTypeAlias
+    summary: A type alias
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax: export declare type ExampleTypeAlias = Promise<boolean>;
+  - name: ExampleUnionTypeAlias
+    uid: 'api-documenter-test!ExampleUnionTypeAlias:type'
+    package: api-documenter-test!
+    fullName: ExampleUnionTypeAlias
+    summary: A type alias that references multiple other types.
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax: export declare type ExampleUnionTypeAlias = IDocInterface1 | IDocInterface3;
+  - name: GenericTypeAlias
+    uid: 'api-documenter-test!GenericTypeAlias:type'
+    package: api-documenter-test!
+    fullName: GenericTypeAlias
+    summary: ''
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax: 'export declare type GenericTypeAlias<T> = T[];'
+  - name: TypeAlias
+    uid: 'api-documenter-test!TypeAlias:type'
+    package: api-documenter-test!
+    fullName: TypeAlias
+    summary: ''
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax: export declare type TypeAlias = number;
 functions:
   - name: 'exampleFunction(x, y)'
     uid: 'api-documenter-test!exampleFunction:function(1)'


### PR DESCRIPTION
A proof-of-concept PR for adding type alias support to the YAML Documenter. Any work here is dependent on the YAML schema being supported by DocFX.